### PR TITLE
fix: ingredients are text, not strings

### DIFF
--- a/priv/repo/migrations/20250928172913_alter_recipe_ingredients_text.exs
+++ b/priv/repo/migrations/20250928172913_alter_recipe_ingredients_text.exs
@@ -1,0 +1,9 @@
+defmodule Talisman.Repo.Migrations.AlterRecipeIngredientsText do
+  use Ecto.Migration
+
+  def change do
+    alter table(:recipes) do
+      modify :ingredients, {:array, :text}
+    end
+  end
+end

--- a/test/talisman/cookbooks/aggregates/cookbook_test.exs
+++ b/test/talisman/cookbooks/aggregates/cookbook_test.exs
@@ -97,6 +97,47 @@ defmodule Talisman.Cookbooks.Aggregates.CookbookTest do
         }
       ])
     end
+
+    test "should succeed with a very long recipe (255+ chars)" do
+      %CreateCookbook{
+        author_uuid: author_uuid,
+        cookbook_uuid: cookbook_uuid
+      } = create_cookbook_command = build(:create_cookbook_command)
+
+      %AddRecipe{
+        recipe_uuid: recipe_uuid
+      } =
+        add_recipe_command =
+        build(:add_recipe_command, author_uuid: author_uuid, cookbook_uuid: cookbook_uuid)
+
+      %EditRecipe{
+        recipe: new_recipe,
+        name: new_name,
+        ingredients: new_ingredients,
+        category: new_category
+      } =
+        edit_recipe_command =
+        build(:edit_recipe_command,
+          cookbook_uuid: cookbook_uuid,
+          recipe_uuid: recipe_uuid,
+          recipe:
+            "Marinare il pollo almeno 20 minuti nella marinatura. Cuocerlo in padella con olio qb. Toglierlo e nella stessa padella cuocere funghi, aglio, zenzero (aggiungere olio e/o acqua). Quando sono praticamente cotti, aggiungere la salsa e girare finché non si addensa. Rimettere il pollo per uno o due minuti. Servire",
+          ingredients: [
+            "Per la marinatura: 2 tbsp salsa di soia, 1 tbsp sake o vino,1 tbsp olio di sesamo, 1 tbsp amido di mais e 300 gr pollo. Per la salsa: 2 tbsp oyster sauce, 1 tbsp olio di sesamo,1 cucchiaino di zucchero, brodo 125 gr, 1 tbsp amido mais. Altro: funghi, zenzero, aglio"
+          ]
+        )
+
+      assert_events([create_cookbook_command, add_recipe_command, edit_recipe_command], [
+        %RecipeEdited{
+          recipe_uuid: recipe_uuid,
+          cookbook_uuid: cookbook_uuid,
+          name: new_name,
+          recipe: new_recipe,
+          ingredients: new_ingredients,
+          category: new_category
+        }
+      ])
+    end
   end
 
   describe "like recipe" do

--- a/test/talisman/cookbooks_test.exs
+++ b/test/talisman/cookbooks_test.exs
@@ -188,6 +188,65 @@ defmodule Talisman.CookbooksTest do
              } = Cookbooks.get_cookbook(cookbook_uuid)
     end
 
+    test "create a cookbook, append a recipe to it, with an empty category, then edit it successfully with 255+ chars ingredients" do
+      %{author_uuid: author_uuid} =
+        new_cookbook = %{author_uuid: Faker.UUID.v4(), name: Faker.Pokemon.name(), recipes: []}
+
+      assert :ok = Cookbooks.create_cookbook(new_cookbook)
+
+      [%Cookbook{uuid: cookbook_uuid}] = Cookbooks.get_cookbooks_by_author_uuid(author_uuid)
+
+      %{name: recipe_name, recipe: recipe_body, ingredients: recipe_ingredients} =
+        new_recipe = %{
+          cookbook_uuid: cookbook_uuid,
+          author_uuid: author_uuid,
+          name: Faker.Food.dish(),
+          recipe: Faker.Lorem.paragraph(),
+          ingredients: [Faker.Food.ingredient(), Faker.Food.ingredient()]
+        }
+
+      assert :ok = Cookbooks.add_recipe(new_recipe)
+
+      assert %Cookbook{
+               uuid: ^cookbook_uuid,
+               recipes: [
+                 %Recipe{
+                   uuid: recipe_uuid,
+                   name: ^recipe_name,
+                   recipe: ^recipe_body,
+                   ingredients: ^recipe_ingredients
+                 }
+               ]
+             } = Cookbooks.get_cookbook(cookbook_uuid)
+
+      edited_recipe_body = Faker.Lorem.paragraph()
+
+      edited_ingredients = [
+        "Per la marinatura: 2 tbsp salsa di soia, 1 tbsp sake o vino,1 tbsp olio di sesamo, 1 tbsp amido di mais e 300 gr pollo. Per la salsa: 2 tbsp oyster sauce, 1 tbsp olio di sesamo,1 cucchiaino di zucchero, brodo 125 gr, 1 tbsp amido mais. Altro: funghi, zenzero, aglio"
+      ]
+
+      assert :ok =
+               Cookbooks.edit_recipe(author_uuid, %{
+                 cookbook_uuid: cookbook_uuid,
+                 recipe_uuid: recipe_uuid,
+                 name: recipe_name,
+                 recipe: edited_recipe_body,
+                 ingredients: edited_ingredients,
+                 category: ""
+               })
+
+      assert %Cookbook{
+               uuid: ^cookbook_uuid,
+               recipes: [
+                 %Recipe{
+                   name: ^recipe_name,
+                   recipe: ^edited_recipe_body,
+                   ingredients: ^edited_ingredients
+                 }
+               ]
+             } = Cookbooks.get_cookbook(cookbook_uuid)
+    end
+
     test "create a cookbook, append a recipe to it, with an empty category, then delete it" do
       %{author_uuid: author_uuid} =
         new_cookbook = %{author_uuid: Faker.UUID.v4(), name: Faker.Pokemon.name(), recipes: []}


### PR DESCRIPTION
A very unpleasant experience with postgres strings led us to store ingredients as `:text`, not `:string`